### PR TITLE
fix(app): sessions the app launches were never reachable from the phone

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -134,6 +134,11 @@ function applyTheme(mode) {
 let SHOWWK = true; // calendar week numbers (Glass parity; Settings toggle repaints live)
 let KILLBEHAVIOR = 'ask'; // Glass parity: how the trash button behaves — ask | kill | capture (Settings changes it live)
 let OPENNOTESIN = 'rendered'; // Glass "Open files in": a note opens rendered (default) or as raw source
+// Mirrors Settings > Claude > Remote control (Claude's own `remoteControlAtStartup`). Held here
+// so a launch can PASS the flag rather than trust the setting to be honoured — see
+// claudeLaunchCmd. Starts false and is corrected below; false is also Claude's real default.
+let REMOTE = false;
+void window.glassShell.claudeConfig().then((c) => { REMOTE = c.remoteControl === true; }).catch(() => { /* keep false */ });
 void window.glassShell.shellConfig().then((c) => {
   CLAUDE = c.claudeCmd || 'claude';
   KILLBEHAVIOR = c.killBehavior || 'ask';
@@ -4095,6 +4100,17 @@ function shq(s) { return `'${s.replace(/'/g, `'\\''`)}'`; }
 // The first prompt handed to a session launched with no explicit task — it triggers
 // the Session Start Ritual (CLAUDE.md), exactly like the `spawn` wrapper's bootstrap.
 const RITUAL_BOOTSTRAP = 'Start session';
+/* Every Claude session this renderer launches is BUILT here. Three call sites used to
+   concatenate their own `--name` string, so a flag added to one reached none of the others —
+   which is exactly how --remote-control went missing while --name was present everywhere.
+   The main process has the same shape in buildSpawnCmd; the renderer cannot import it (no
+   bundler — app.js is a plain <script>), so this is the renderer's half of that chokepoint. */
+function claudeLaunchCmd(name, task) {
+  const parts = [CLAUDE];
+  if (REMOTE) parts.push('--remote-control');
+  parts.push('--name', name, shq(task || RITUAL_BOOTSTRAP));
+  return parts.join(' ');
+}
 
 /* Spawn a session whose NAME carries its identity. Everything that wants an agent to BE
    something (rather than to be asked about it) goes through here: --name sets
@@ -4108,7 +4124,7 @@ const RITUAL_BOOTSTRAP = 'Start session';
    shoots a session that is not recognised as a session".
    The pane already had a name for its tab; it just never reached Claude. One builder now emits
    both from the same string, so they cannot drift. */
-const ritual = (name, slash) => ({ name, cmd: CLAUDE + ' --name ' + name + ' ' + shq(slash) });
+const ritual = (name, slash) => ({ name, cmd: claudeLaunchCmd(name, slash) });
 
 function spawnNamed(name, task) {
   const handle = (name || '').trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
@@ -4124,7 +4140,7 @@ function spawnNamed(name, task) {
      I tried watching the terminal for the composer instead and abandoned it: a regex against
      another product's UI, which read scrollback as current state and which I could not simulate
      faithfully enough to trust. Removing the screen is deterministic; guessing at it is not. */
-  void createPane({ name: handle, cmd: CLAUDE + ' --name ' + handle + ' ' + shq(task || RITUAL_BOOTSTRAP) });
+  void createPane({ name: handle, cmd: claudeLaunchCmd(handle, task) });
 }
 
 
@@ -4669,7 +4685,11 @@ function openSettingsTab() {
       t.addEventListener('change', async () => { await window.glassShell.claudeSet(key, t.checked); toast(window.i18n.t('settings.saved')); });
       return t;
     };
-    row(wrap, t('settings.remoteControl'), mkCToggle('remoteControl', cc.remoteControl), t('settings.remoteControlHint'));
+    // Also update the in-memory flag: claudeLaunchCmd reads REMOTE, and without this the
+    // toggle would only take effect after a restart — the kind of gap that reads as "it didn't work".
+    const rcT = mkCToggle('remoteControl', cc.remoteControl);
+    rcT.addEventListener('change', () => { REMOTE = rcT.checked; });
+    row(wrap, t('settings.remoteControl'), rcT, t('settings.remoteControlHint'));
     row(wrap, t('settings.claudeInChrome'), mkCToggle('claudeInChrome', cc.claudeInChrome), t('settings.claudeInChromeHint'));
     row(wrap, t('settings.copyOnSelect'), mkCToggle('copyOnSelect', cc.copyOnSelect), t('settings.copyOnSelectHint'));
     row(wrap, t('settings.notify'), mkCToggle('agentPushNotif', cc.agentPushNotif), t('settings.notifyHint'));
@@ -4762,6 +4782,7 @@ function openSettingsTab() {
     cmd.className = 'tinput'; cmd.value = cfg.claudeCmd;
     cmd.addEventListener('change', async () => { await window.glassShell.setSetting('claudeCmd', cmd.value.trim() || 'claude'); CLAUDE = cmd.value.trim() || 'claude'; toast(t('settings.savedNewSessions')); });
     row(wrapAdv, t('settings.claudeCmd'), cmd, t('settings.claudeCmdHint'));
+
   });
 }
 
@@ -5500,7 +5521,7 @@ async function openPalette() {
   const v = await listModal(t('palette.title'), items, t('palette.placeholder'));
   if (!v) return;
   if (v.t === 'pane') void createPane({ name: v.name, cmd: v.cmd });
-  else if (v.t === 'ask') { const i = await askWithChips(); if (i) { const slug = ('ask-' + i.toLowerCase().replace(/[^a-z0-9]+/g, '-')).slice(0, 28).replace(/-+$/, ''); const p2 = 'Find the right AIOS action for this intent and run it: "' + i + '". Pick the best match, say which in one line, then execute.'; const h2 = await window.glassShell.taskHandoff(p2, slug).catch(() => p2); void createPane({ name: slug, cmd: CLAUDE + ' --name ' + slug + ' ' + shq(h2) }); } }
+  else if (v.t === 'ask') { const i = await askWithChips(); if (i) { const slug = ('ask-' + i.toLowerCase().replace(/[^a-z0-9]+/g, '-')).slice(0, 28).replace(/-+$/, ''); const p2 = 'Find the right AIOS action for this intent and run it: "' + i + '". Pick the best match, say which in one line, then execute.'; const h2 = await window.glassShell.taskHandoff(p2, slug).catch(() => p2); void createPane({ name: slug, cmd: claudeLaunchCmd(slug, h2) }); } }
   else if (v.t === 'settings') openSettingsTab();
   else if (v.t === 'setup') openSetupTab();
   else if (v.t === 'plugins') openPluginsTab();
@@ -5528,7 +5549,7 @@ async function spawnWorkerFlow() {
   // A bootstrap prompt is what makes the SESSION RITUAL run on turn one (identity →
   // agent match → context load). The spawn wrapper always passes one; a bare
   // `claude --name X` would sit idle and skip the ritual. No task → "Start session".
-  void createPane({ name: handle, cmd: CLAUDE + ' --name ' + handle + ' ' + shq(task || RITUAL_BOOTSTRAP) });
+  void createPane({ name: handle, cmd: claudeLaunchCmd(handle, task) });
 }
 
 /* Create a custom agent / skill / plugin — scaffolds into the right custom/ dir. */
@@ -5702,7 +5723,7 @@ function openDesignerTab() {
 function launchPrimary(primary) {
   const hit = byName(primary);
   if (hit && !panes.get(hit[0]).exited) { setActive(hit[0]); return; }
-  void createPane({ name: primary, cmd: CLAUDE + ' --name ' + primary + ' ' + shq(RITUAL_BOOTSTRAP) });
+  void createPane({ name: primary, cmd: claudeLaunchCmd(primary) });
 }
 
 /* Rituals + nudges run in the PRIMARY session (Glass parity) — reuse it when it
@@ -5715,7 +5736,7 @@ async function runInPrimary(slash) {
     submitToPty(hit[0], slash);
     setActive(hit[0]);
   } else {
-    void createPane({ name: primary, cmd: CLAUDE + ' --name ' + primary + ' ' + shq(slash) });
+    void createPane({ name: primary, cmd: claudeLaunchCmd(primary, slash) });
   }
 }
 
@@ -5734,10 +5755,10 @@ async function runWhere(slash, name) {
   ];
   const choice = await listModal(t('run.where'), choices, t('run.wherePlaceholder'));
   if (!choice) return;
-  if (choice === '__new') { void createPane({ name: name || 'run', cmd: CLAUDE + ' --name ' + (name || 'run') + ' ' + shq(slash) }); return; }
+  if (choice === '__new') { void createPane({ name: name || 'run', cmd: claudeLaunchCmd(name || 'run', slash) }); return; }
   const hit = byName(choice);
   if (hit && !panes.get(hit[0]).exited) { submitToPty(hit[0], slash); setActive(hit[0]); }
-  else void createPane({ name: name || choice, cmd: CLAUDE + ' --name ' + (name || choice) + ' ' + shq(slash) });
+  else void createPane({ name: name || choice, cmd: claudeLaunchCmd(name || choice, slash) });
 }
 
 function runFrequent(t) {

--- a/src/core/claudeConfig.ts
+++ b/src/core/claudeConfig.ts
@@ -34,7 +34,10 @@ export const CLAUDE_KEYS: Record<string, ClaudeKeySpec> = {
   // ── confirmed present in ~/.claude/settings.json on a real machine ──
   model: { path: 'model', store: 'settings', kind: 'enum', fallback: '' },
   mode: { path: 'permissions.defaultMode', store: 'settings', kind: 'enum', fallback: 'default' },
-  remoteControl: { path: 'remoteControlAtStartup', store: 'settings', kind: 'bool', fallback: true },
+  /* fallback FALSE. Claude does not enable Remote Control unless the key is set, so a `true`
+     fallback made the toggle read ON while every app-launched session was in fact unreachable
+     from the operator's phone — a setting that lies in the safe-looking direction. */
+  remoteControl: { path: 'remoteControlAtStartup', store: 'settings', kind: 'bool', fallback: false },
   switchModelsOnFlag: { path: 'switchModelsOnFlag', store: 'settings', kind: 'bool', fallback: false },
   // ── in the settings-key table, unset until changed ──
   outputStyle: { path: 'outputStyle', store: 'settings', kind: 'enum', fallback: 'default' },

--- a/src/core/commandBus.ts
+++ b/src/core/commandBus.ts
@@ -119,15 +119,25 @@ export function taskFileInstruction(file: string): string {
  * Build the `claude --name …` command the app runs in a pane. `taskFile`, when
  * given, replaces the inline task with a read-the-file instruction (see
  * needsTaskFile). model beats tier; a bare spawn is just `claude --name <n>`.
+ *
+ * `remoteControl` (default true) adds --remote-control, which is what publishes the session
+ * to the operator's own Anthropic account so claude.ai and the mobile app can attach to it.
+ * The `spawn` wrapper passes it unconditionally; omitting it here is what made app-launched
+ * sessions the only ones invisible from a phone. Pass false to opt out.
  */
 export function buildSpawnCmd(
   claudeCmd: string,
   name: string,
-  opts: { task?: string; model?: string; tier?: 'mechanical' | 'judgment'; taskFile?: string } = {},
+  opts: { task?: string; model?: string; tier?: 'mechanical' | 'judgment'; taskFile?: string; remoteControl?: boolean } = {},
 ): string {
   const model = opts.model ?? (opts.tier ? tierToModel(opts.tier) : undefined);
   const parts = [claudeCmd || 'claude'];
   if (model) parts.push('--model', model);
+  // Emitted BEFORE --name, which is the exact order the `spawn` wrapper has shipped for months
+  // (`claude … --remote-control --name <n> <bootstrap>`). Worth pinning rather than leaving to
+  // taste: --remote-control takes an OPTIONAL positional name of its own, so the ordering is
+  // load-bearing and this is the arrangement with a track record.
+  if (opts.remoteControl !== false) parts.push('--remote-control');
   parts.push('--name', name);
   const prompt = opts.taskFile ? taskFileInstruction(opts.taskFile) : opts.task;
   if (prompt && prompt.trim()) parts.push(shq(prompt));

--- a/src/main/commandBus.ts
+++ b/src/main/commandBus.ts
@@ -360,6 +360,7 @@ function runImmediate(win: () => BrowserWindow | undefined, heldPath: string, re
       // one instead of sitting idle (mirrors the `spawn` wrapper).
       const cmd = buildSpawnCmd(aios.shellSettings().claudeCmd, req.name, {
         task: req.task || 'Start session', model: req.model, tier: req.tier, taskFile,
+        remoteControl: aios.claudeConfig().remoteControl,
       });
       emit(win(), 'terminal', { name: req.name, cmd });
       log(`spawn '${req.name}'${req.task ? ' with task' : ''}${req.model ? ` [model ${req.model}]` : req.tier ? ` [tier ${req.tier}]` : ''}${taskFile ? ' (task via file)' : ''}`);

--- a/src/main/panelHost.ts
+++ b/src/main/panelHost.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { BrowserWindow, WebContents } from 'electron';
 import * as aios from './aios';
+import { buildSpawnCmd } from '../core/commandBus';
 
 /** Framework-status cadence: poll while on screen, and collapse rapid triggers. */
 const UPD_POLL_MS = 5 * 60_000;
@@ -252,12 +253,21 @@ export class PanelHost {
   /** `run('aios.x')` command ids → shell actions. Pickers come with the palette stride. */
   private routeCommand(command: string, args: unknown[]): void {
     const term = (name: string, cmd: string) => this.intent('terminal', { name, cmd });
+    // One place the panel's session launches are BUILT, so a flag added to buildSpawnCmd
+    // reaches them without each case having to remember it.
+    const spawnCmd = (name: string, task?: string): string => {
+      return buildSpawnCmd(aios.shellSettings().claudeCmd, name, {
+        task, remoteControl: aios.claudeConfig().remoteControl,
+      });
+    };
     switch (command) {
       case 'aios.openConfigMenu': this.intent('settings'); return;
       /* --name, so this is a SESSION. Without it termEnv() cannot set CLAUDE_AGENT_NAME, the
          identity ritual never runs, and it never registers in ~/.claude/sessions — the operator
-         gets an unnamed terminal they cannot resume and cannot find in Running. */
-      case 'aios.updateFramework': term('update', `${aios.shellSettings().claudeCmd} --name update '/aios:update'`); return;
+         gets an unnamed terminal they cannot resume and cannot find in Running.
+         Built by buildSpawnCmd rather than by hand: --name was not the only flag a launch site
+         could forget, and every site that spelled its own command forgot --remote-control. */
+      case 'aios.updateFramework': term('update', spawnCmd('update', '/aios:update')); return;
       case 'aios.frequentMenu': this.intent('pickFrequent'); return;
       case 'aios.spawnAgent': this.intent('pickAgent'); return;
       case 'aios.skillsPicker': this.intent('pickSkill'); return;
@@ -286,7 +296,7 @@ export class PanelHost {
       case 'aios.toggleHome': this.intent('layout', { togglePanel: true }); return;
       case 'aios.dailyPicker': this.intent('pickDaily'); return;
       case 'aios.openWalkthrough': this.intent('setup'); return;
-      case 'aios.launchPrimary': { const p = aios.primaryName(); term(p, `${aios.shellSettings().claudeCmd} --name ${p}`); return; }
+      case 'aios.launchPrimary': { const p = aios.primaryName(); term(p, spawnCmd(p)); return; }
       case 'aios.resume': term('resume', 'claude --resume'); return;
       case 'aios.askAios': this.intent('ask'); return;
       case 'aios.revealAgent': this.intent('focusByName', { name: String(args[0] ?? '') }); return;

--- a/src/test/claudeConfig.test.ts
+++ b/src/test/claudeConfig.test.ts
@@ -48,7 +48,11 @@ test('dot paths read and write nested keys, and create what is missing', () => {
 });
 
 test('absent means the fallback — Claude only writes a key once you change it', () => {
-  assert.equal(readValue('remoteControl', {}, {}), true, 'remote control defaults ON');
+  // Remote Control is OFF until `remoteControlAtStartup` is written. This assertion used to say
+  // ON, and that single wrong belief is what made the failure invisible: the Settings row read
+  // "Remote control ✓" while every session the app launched was unreachable from the operator's
+  // phone. A fallback is a CLAIM ABOUT CLAUDE, so a wrong one is not a cosmetic default.
+  assert.equal(readValue('remoteControl', {}, {}), false, 'remote control defaults OFF until the key is written');
   assert.equal(readValue('reduceMotion', {}, {}), false);
   assert.equal(readValue('outputStyle', {}, {}), 'default');
   assert.equal(readValue('mode', {}, {}), 'default');

--- a/src/test/commandBus.test.ts
+++ b/src/test/commandBus.test.ts
@@ -95,16 +95,18 @@ test('shq: POSIX single-quote escaping (embedded quotes safe)', () => {
 });
 
 test('buildSpawnCmd: bare · task · model · tier · model-beats-tier · task-file', () => {
-  assert.equal(buildSpawnCmd('claude', 'heron', {}), 'claude --name heron');
-  assert.equal(buildSpawnCmd('claude', 'heron', { task: 'do it' }), "claude --name heron 'do it'");
-  assert.equal(buildSpawnCmd('claude', 'heron', { model: 'claude-opus-4-8', task: 'x' }), "claude --model claude-opus-4-8 --name heron 'x'");
-  assert.equal(buildSpawnCmd('claude', 'heron', { tier: 'mechanical' }), 'claude --model claude-sonnet-5 --name heron');
+  // These pin the command the app ACTUALLY runs, --remote-control included, rather than a
+  // configuration nobody uses — so a change to the default shape has to come through here.
+  assert.equal(buildSpawnCmd('claude', 'heron', {}), 'claude --remote-control --name heron');
+  assert.equal(buildSpawnCmd('claude', 'heron', { task: 'do it' }), "claude --remote-control --name heron 'do it'");
+  assert.equal(buildSpawnCmd('claude', 'heron', { model: 'claude-opus-4-8', task: 'x' }), "claude --model claude-opus-4-8 --remote-control --name heron 'x'");
+  assert.equal(buildSpawnCmd('claude', 'heron', { tier: 'mechanical' }), 'claude --model claude-sonnet-5 --remote-control --name heron');
   // explicit model beats tier
-  assert.equal(buildSpawnCmd('claude', 'heron', { model: 'claude-opus-4-8', tier: 'mechanical' }), 'claude --model claude-opus-4-8 --name heron');
+  assert.equal(buildSpawnCmd('claude', 'heron', { model: 'claude-opus-4-8', tier: 'mechanical' }), 'claude --model claude-opus-4-8 --remote-control --name heron');
   // task-file replaces the inline task with a read-instruction
   assert.equal(
     buildSpawnCmd('claude', 'heron', { task: 'huge...', taskFile: '/tmp/aios-spawn-task-heron.md' }),
-    `claude --name heron ${shq(taskFileInstruction('/tmp/aios-spawn-task-heron.md'))}`,
+    `claude --remote-control --name heron ${shq(taskFileInstruction('/tmp/aios-spawn-task-heron.md'))}`,
   );
   // a custom claudeCmd is honored (Settings override)
   assert.ok(buildSpawnCmd('claude-fast', 'heron', {}).startsWith('claude-fast '));
@@ -128,4 +130,25 @@ test('INVARIANT: verbs reuse existing renderer intents (no bespoke renderer code
   for (const intent of ['terminal', 'closeByName', 'sendByName', 'focusByName']) {
     assert.match(src, new RegExp(`'${intent}'`), `bus must emit the existing '${intent}' intent`);
   }
+});
+
+/* Remote Control reaches the command line, not just the settings file (2026-07-31).
+   `remoteControlAtStartup` is honoured inconsistently across hosts — there are open upstream
+   reports of it being read and ignored — so a toggle that only writes that key can be ON and
+   have no effect. Passing --remote-control on the launch itself is the mechanism with a track
+   record: it is what the `spawn` wrapper has always done, and wrapper-launched sessions were
+   the only ones that ever appeared on the operator's phone. */
+test('buildSpawnCmd passes --remote-control by default, before --name', () => {
+  const cmd = buildSpawnCmd('claude', 'ali');
+  assert.match(cmd, /--remote-control/, 'a launch must publish the session by default');
+  assert.ok(
+    cmd.indexOf('--remote-control') < cmd.indexOf('--name'),
+    '--remote-control takes an OPTIONAL positional name of its own, so ordering is load-bearing; this is the order the spawn wrapper ships',
+  );
+});
+
+test('buildSpawnCmd omits --remote-control when the operator has turned it off', () => {
+  const cmd = buildSpawnCmd('claude', 'ali', { remoteControl: false });
+  assert.doesNotMatch(cmd, /--remote-control/, 'opting out must actually opt out');
+  assert.match(cmd, /--name ali/, 'and the session must still be named');
 });

--- a/src/test/menu.test.ts
+++ b/src/test/menu.test.ts
@@ -127,7 +127,7 @@ test('a named spawn IS the identity — the session becomes the agent', () => {
   // a session adopt a bundled agent on turn one. Running a slash command in the primary
   // session tells it ABOUT the agent instead, and cannot be closed independently.
   assert.match(app, /function spawnNamed\(name, task\)/);
-  assert.match(app, /CLAUDE \+ ' --name ' \+ handle/);
+  assert.match(app, /claudeLaunchCmd\(handle, task\)/, 'built by the one renderer chokepoint, so --name and --remote-control travel together');
   assert.match(app, /const hit = byName\(handle\);/, 'reveal an open one rather than duplicating');
   assert.match(app, /case 'spawnNamed':/);
   // the title-bar compass uses the same path as the menu
@@ -469,7 +469,7 @@ test('a ritual launches as a named SESSION, never an anonymous terminal', () => 
      ~/.claude/sessions. The operator gets an unnamed terminal they cannot resume and cannot find in
      Running — reported on the update pill as "a session that is not recognised as a session".
      The pane always had a name for its tab; it just never reached Claude. */
-  assert.match(app, /const ritual = \(name, slash\) => \(\{ name, cmd: CLAUDE \+ ' --name ' \+ name \+ ' ' \+ shq\(slash\) \}\)/,
+  assert.match(app, /const ritual = \(name, slash\) => \(\{ name, cmd: claudeLaunchCmd\(name, slash\) \}\)/,
     'one builder emits the tab name and the session name from the same string');
   // no ritual may be launched the old way — a bare slash command with no --name
   const orphans = [...app.matchAll(/cmd: CLAUDE \+ " '\/[a-z:-]+'"/g)].map((m) => m[0]);
@@ -478,7 +478,9 @@ test('a ritual launches as a named SESSION, never an anonymous terminal', () => 
     assert.ok(app.includes(`ritual('${r}'`), `${r} must go through the builder`);
   }
   const panel = fs.readFileSync('src/main/panelHost.ts', 'utf8');
-  assert.match(panel, /--name update '\/aios:update'/, 'the update pill launches a named session');
+  // Built by spawnCmd() now rather than spelled inline, so assert the CALL, not the string:
+  // the launch has to carry --remote-control too, and a literal is the wrong thing to pin.
+  assert.match(panel, /spawnCmd\('update', '\/aios:update'\)/, 'the update pill launches a named session via the builder');
 });
 
 test('no stray keyword was left dangling by an edit', () => {

--- a/src/test/termenv.test.ts
+++ b/src/test/termenv.test.ts
@@ -54,3 +54,30 @@ test('INVARIANT: paste is never hand-rolled — one write, bracketed', () => {
   assert.doesNotMatch(app, /k === 'v'\s*\)\s*\{[^}]*ptyWrite/, 'Cmd+V must not write the clipboard itself');
   assert.match(app, /k === 'c'/, "Cmd+C must stay — xterm has no native copy for a terminal selection");
 });
+
+/* Every launch site is BUILT, never concatenated (2026-07-31).
+   --remote-control went missing from the app for the same structural reason --name once did:
+   six places each spelled their own `claude …` string, so a flag added to one reached none of
+   the others. The main process routes through buildSpawnCmd; the renderer cannot import it
+   (app.js is a plain <script>, no bundler), so it has claudeLaunchCmd as its half of the same
+   chokepoint. These assertions exist so the next flag has one place to be added. */
+test('INVARIANT: the renderer builds every Claude launch in one place', () => {
+  const app = fs.readFileSync('renderer/app.js', 'utf8');
+  assert.match(app, /function claudeLaunchCmd\(name, task\)/, 'the renderer chokepoint must exist');
+  assert.doesNotMatch(
+    app, /CLAUDE \+ ' --name '/,
+    'no pane may concatenate its own launch command — that duplication is what lost --remote-control',
+  );
+  assert.match(app, /if \(REMOTE\) parts\.push\('--remote-control'\)/, 'the renderer must pass the flag when Remote Control is on');
+});
+
+test('INVARIANT: the main process builds its launches too, and sources the flag from Claude config', () => {
+  const panel = fs.readFileSync('src/main/panelHost.ts', 'utf8');
+  assert.match(panel, /buildSpawnCmd\(/, 'panelHost must build, not concatenate');
+  assert.doesNotMatch(panel, /claudeCmd\} --name/, 'no template-literal launch commands');
+  // One toggle, not two: Settings already exposes Claude's own remoteControlAtStartup, so the
+  // flag must follow THAT value rather than introduce a second competing switch.
+  assert.match(panel, /aios\.claudeConfig\(\)\.remoteControl/, 'the flag must follow the existing Remote control toggle');
+  const bus = fs.readFileSync('src/main/commandBus.ts', 'utf8');
+  assert.match(bus, /remoteControl: aios\.claudeConfig\(\)\.remoteControl/, 'the bus spawn must follow it as well');
+});


### PR DESCRIPTION
## What this fixes

A session started from the app never appeared in claude.ai or the Claude mobile app. One started by typing `spawn <name>` in a terminal always did.

The difference is one flag. `--remote-control` is what publishes a session to the operator's own Anthropic account so other devices can attach to it. The `spawn` wrapper passes it on every launch ([`install-wrappers.sh`](https://github.com/The-AIOS/aios/blob/main/hooks/claude-identity/install-wrappers.sh) L216/L218). The app passed it nowhere.

## How it was found

An operator asked why his sessions weren't on his phone. On his machine, all four running sessions showed `claude --name <x>` with no `--remote-control`, while `~/.claude.json` recorded `hasUsedRemoteControl: true` and `remoteControlSurfacesSeen: ["mobile"]` — Remote Control had demonstrably worked for him, just never from the app.

## Two causes, not one

**1 · Nine launch sites, each spelling its own command.** Six in `renderer/app.js`, two in `panelHost.ts`, one via `buildSpawnCmd`. A flag added to one reached none of the others.

This is the same shape as the bug `termenv.test.ts` already documents — *"a path that never spells `--name` came up unnamed with nothing reporting it."* `--name` was eventually fixed at every site; `--remote-control` was never added at any. The duplication is the actual defect; the missing flag is what it produced this time.

Everything now builds through `buildSpawnCmd`, or through a new `claudeLaunchCmd` in the renderer, which cannot import it (`app.js` is a plain `<script>` — no bundler). Worth stating plainly: **the invariant test found five renderer sites my manual pass had missed.** I thought there were three.

**2 · The `remoteControl` fallback claimed `true`.** Claude leaves Remote Control off until `remoteControlAtStartup` is written, so Settings › Claude showed the toggle **on** while every app-launched session was unreachable. `fallback` is documented in this file as *"Value when the key is absent"* — a claim about Claude's behaviour — so a wrong one is not a cosmetic default. It is why this was invisible rather than merely broken. `claudeConfig.test.ts` asserted the same wrong belief (`'remote control defaults ON'`), so the suite agreed with the bug.

## Why the flag rather than the setting

`remoteControlAtStartup` is honoured inconsistently across hosts — several open reports of it being read and ignored ([#54527](https://github.com/anthropics/claude-code/issues/54527), [#53647](https://github.com/anthropics/claude-code/issues/53647), [#41036](https://github.com/anthropics/claude-code/issues/41036)). Writing the key alone can leave a toggle that is on and does nothing. Passing the flag is the mechanism with a track record: it is what the wrapper does, and wrapper-launched sessions are the ones that reached the operator's phone.

**No new setting.** Settings › Claude › Remote control already exists and writes that key. It now also drives the flag, and updates the in-memory value live, so it takes effect on the next launch instead of after a restart.

## The question for you, which the patch does not settle

**Was leaving Remote Control off deliberate?** I could find no note either way — no mention of remote control, mobile or claude.ai in `README.md`, `DESIGN.md` or `CLAUDE.md`. Publishing a session to an account is a real surface-area decision and it may have been yours to make.

If the answer is "on by default," this is ready. If it is "off unless asked," change one line — `fallback: false` already makes the toggle honest, and the flag simply follows it. I did not want to assume.

## Gates

| Gate | Result |
|---|---|
| `npm test` | Passes, except three `busDelivery` E2E tests that **fail identically on pristine `main`** — baselined by stashing this branch and re-running |
| `npm run check:tokens` | ✓ clean |
| `npm run smoke` | `setup=false` + `VIEWER FAILED` — **also fails identically on pristine `main`**, same baseline method |
| `npm run dist` | Packages and builds the DMG; `verify:package` then re-runs the same packaged smoke and reports the same two pre-existing steps |

One observation offered without a claim attached: both smoke runs reported `operator=Luigi, agents=115`, so the harness resolved my real framework root rather than a fixture. That may be why the viewer step fails here and not on your machine — worth a look independently of this PR.

## Tests added

- `buildSpawnCmd` emits the flag by default, omits it on opt-out, and emits it **before** `--name` (`--remote-control` takes an optional positional name, so ordering is load-bearing; this is the wrapper's order).
- The corrected fallback, with a comment recording what the old assertion cost.
- Two invariants asserting no launch site concatenates its own command — the ones that caught the five sites.

The exact-string assertions in `commandBus.test.ts` were updated to the real default output rather than pinned to a non-default configuration, so a future change to the launch shape has to come through them.
