### PR TITLE
fix: a CI framework fixture, and desktopName fixes the cause not the symptom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,25 @@ jobs:
       - run: npm ci
       - run: npx electron-rebuild -f -w node-pty
       - run: npm run compile
+
+      # Two smoke gates read the operator's framework — one discovers agents/commands/skills, one
+      # opens a file and counts what rendered. A bare runner has neither, so they used to fail on
+      # ABSENT FIXTURES rather than on the build, which is why smoke was kept out of the release
+      # lane. They now skip when there is no framework root, which is honest but leaves a worse
+      # hole: a gate that CAN skip will eventually skip silently.
+      #
+      # So provide a root, then forbid skipping. AIOS_SMOKE_STRICT=1 turns "did not run" into a
+      # failure — if the fixture ever stops taking effect, CI says so instead of quietly measuring
+      # nothing. The fixture is synthetic by construction and grants NO workspace folder, so the
+      # viewer gate has to reach its probe through the framework root alone (granting one would
+      # mask the very bug that made that gate pass on one machine and fail everywhere else).
+      - name: Minimal framework fixture, so the gates run instead of skipping
+        run: node scripts/make-vault-fixture.mjs --out "$RUNNER_TEMP/aios-fixture"
+
       - run: npm run smoke
+        env:
+          GLASS_FRAMEWORK_PATH: ${{ runner.temp }}/aios-fixture
+          AIOS_SMOKE_STRICT: '1'
 
   linux-dist:
     # Why this exists: a contributor's "it builds and the gates pass on Linux Mint" is a claim,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aios-app",
   "productName": "AIOS",
   "version": "0.8.1",
+  "desktopName": "aios.desktop",
   "description": "AIOS App — the one-for-all AIOS desktop application. Glass, not engine.",
   "license": "GPL-2.0-or-later",
   "main": "out/main/main.js",

--- a/scripts/make-vault-fixture.mjs
+++ b/scripts/make-vault-fixture.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * make-vault-fixture — a minimal framework root, so the smoke gates RUN in CI.
+ *
+ * The problem this solves: `npm run smoke` boots the real workbench and asserts things about the
+ * operator's framework — agents discovered, a file that renders. A bare CI runner has none of
+ * that, so two gates failed on absent fixtures rather than on anything about the build, and the
+ * job was kept out of the release lane for exactly that reason. They were then changed to report
+ * SKIPPED instead of failing, which is honest but leaves a worse hole: a gate that CAN skip will
+ * eventually skip silently, and nobody notices the day it stops running for a real reason.
+ *
+ * A fixture closes it from the other side. With a framework root present the gates run — and CI
+ * can additionally set AIOS_SMOKE_STRICT=1, which turns "did not run" into a FAILURE. That is the
+ * combination that makes the check un-skippable where it matters, without making it fail on a
+ * developer's laptop that has no vault.
+ *
+ * Deliberately synthetic. It must never copy from an operator's real vault: this is committed
+ * infrastructure and a real vault is private, so everything here is invented and generic.
+ *
+ * Usage:  node scripts/make-vault-fixture.mjs --out /tmp/aios-fixture
+ * Then:   GLASS_FRAMEWORK_PATH=/tmp/aios-fixture AIOS_SMOKE_STRICT=1 npm run smoke
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const argIdx = process.argv.indexOf('--out');
+const out = argIdx !== -1 && process.argv[argIdx + 1] ? path.resolve(process.argv[argIdx + 1]) : '';
+if (!out) {
+  console.error('make-vault-fixture: ✗ --out <dir> is required');
+  process.exit(1);
+}
+
+const write = (rel, body) => {
+  const p = path.join(out, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, body);
+  return p;
+};
+
+fs.rmSync(out, { recursive: true, force: true });
+fs.mkdirSync(out, { recursive: true });
+
+/* The viewer gate opens the first of README/CLAUDE/CHEATSHEET/SETUP it finds at the root and
+   counts rendered panes, so this needs real markdown with enough block content to render. */
+write('README.md', `# Fixture framework root
+
+This is a **synthetic** AIOS framework root used by CI so the smoke gates have something to
+discover. It is nobody's vault.
+
+## Why it exists
+
+Two smoke gates read the framework: one discovers agents, commands and skills; one opens a file
+and counts what rendered. On a bare runner neither had anything to measure.
+
+- a list item, so the renderer has block content to produce
+- and a second one
+
+\`\`\`bash
+echo "a fenced block, so code rendering is exercised too"
+\`\`\`
+`);
+
+/* discoverAgents walks agents/** recursively, skips _index.md and anything starting with "_",
+   and requires the frontmatter tags block to contain "agent". The parser reads only a
+   block-style list (`tags:` alone on a line, then `- item`) — an inline array is ignored. */
+write('agents/aios/personal/fixture-librarian.md', `---
+tags:
+  - agent
+name: fixture-librarian
+description: A synthetic agent that exists so discovery has something to find.
+---
+# Fixture Librarian
+
+Invented for CI. Does nothing.
+`);
+write('agents/aios/engineering/fixture-mechanic.md', `---
+tags:
+  - agent
+name: fixture-mechanic
+description: A second synthetic agent, so a count of 1 cannot pass by accident.
+---
+# Fixture Mechanic
+`);
+/* These three must be IGNORED by discovery — they prove the filters work rather than assuming it. */
+write('agents/aios/_index.md', `---\ntags:\n  - agent\n---\n# Index — must NOT be discovered\n`);
+write('agents/aios/_scratch.md', `---\ntags:\n  - agent\n---\n# Underscore-prefixed — must NOT be discovered\n`);
+write('agents/aios/not-an-agent.md', `---\ntags:\n  - reference\n---\n# Wrong tag — must NOT be discovered\n`);
+
+/* discoverCommands reads plugins/aios/commands/*.md (flat, skips _index.md). */
+write('plugins/aios/commands/fixture-today.md', `---
+description: A synthetic command.
+argumentHint: "[none]"
+---
+# /fixture-today
+`);
+write('plugins/aios/commands/_index.md', `# Index — must NOT be counted\n`);
+
+/* discoverSkills reads skills/<group>/<name>/SKILL.md. */
+write('skills/aios/fixture-skill/SKILL.md', `---
+name: fixture-skill
+description: A synthetic skill.
+---
+# Fixture Skill
+`);
+
+/* operatorName() resolves from declared context. A name is optional for the gate to pass, but
+   including one exercises that resolution instead of leaving it untested. */
+write('vault/00 - notes/context/declared/about_me.md', `---
+tags:
+  - context
+---
+# About me
+
+My name is Fixture Operator and I do not exist.
+`);
+
+/* Minimal app settings. workspaceFolders is deliberately EMPTY: the viewer gate must reach its
+   probe through the framework root alone. A fixture that also granted a workspace folder could
+   mask the exact bug that made that gate pass on one machine and fail everywhere else. */
+write('.glass/shell.json', JSON.stringify({ workspaceFolders: [] }, null, 2) + '\n');
+
+/* Assert what was produced. A generator that quietly wrote nothing would hand the gates an empty
+   root, and they would skip or fail for the original reason with a fixture nominally "in place". */
+const checks = [
+  ['README.md', (p) => fs.statSync(p).size > 200],
+  ['agents/aios/personal/fixture-librarian.md', (p) => /^tags:\n  - agent$/m.test(fs.readFileSync(p, 'utf8'))],
+  ['agents/aios/engineering/fixture-mechanic.md', () => true],
+  ['plugins/aios/commands/fixture-today.md', () => true],
+  ['skills/aios/fixture-skill/SKILL.md', () => true],
+];
+let bad = 0;
+for (const [rel, ok] of checks) {
+  const p = path.join(out, rel);
+  let good = false;
+  try { good = fs.statSync(p).isFile() && ok(p); } catch { good = false; }
+  if (!good) { console.error(`make-vault-fixture: ✗ ${rel} missing or malformed`); bad++; }
+}
+if (bad) process.exit(1);
+
+console.log(`make-vault-fixture: ✓ ${out}`);
+console.log('  2 discoverable agents (+3 that must be filtered out), 1 command, 1 skill, a README to render');
+console.log(`  use with: GLASS_FRAMEWORK_PATH="${out}" AIOS_SMOKE_STRICT=1 npm run smoke`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -21,6 +21,11 @@ import * as fs from 'fs';
  * then exits 0/1 — the in-app smoke gate, here from day one.
  */
 const SMOKE = process.argv.includes('--smoke');
+/* A gate that CAN skip will eventually skip silently, and nobody notices the day it stops running
+   for a real reason. The two framework-reading gates skip when there is no framework root — right
+   on a developer's laptop, wrong in CI, where a fixture is provided precisely so they run. Strict
+   mode turns "did not run" into a failure, and CI sets it alongside GLASS_FRAMEWORK_PATH. */
+const SMOKE_STRICT = process.env.AIOS_SMOKE_STRICT === '1';
 /* Any uncaught renderer error fails a smoke run — see the verdict block. */
 const rendererErrors: string[] = [];
 const SHOT = process.argv.find((a) => a.startsWith('--shot')); // --shot[=/path.png] : render + screenshot + exit (dev/QA)
@@ -858,8 +863,8 @@ app.whenReady().then(() => {
       try {
         const root = aios.frameworkRoot();
         if (!root) {
-          stateOk = true;   // not a pass on the requirement — a pass on "there was nothing to measure"
-          console.log('shell-smoke: state — SKIPPED (no framework root on this machine; discovery gate did not run)');
+          stateOk = !SMOKE_STRICT;   // not a pass on the requirement — a pass on "nothing to measure"
+          console.log(`shell-smoke: state — ${SMOKE_STRICT ? 'FAILED: strict mode, but there is no framework root to discover — the fixture did not take effect (check GLASS_FRAMEWORK_PATH)' : 'SKIPPED (no framework root on this machine; discovery gate did not run)'}`);
         } else {
           const agents = aios.discoverAgents().length;
           const op = aios.operatorName();
@@ -938,7 +943,8 @@ app.whenReady().then(() => {
       try {
         let viewerOk: number | null = null;   // null = the gate did not run, which is NOT a pass
         if (!probe) {
-          console.log('shell-smoke: viewer — SKIPPED (no framework root on this machine; gate did not run)');
+          if (SMOKE_STRICT) { setupOk = false; console.error('shell-smoke: VIEWER FAILED — strict mode, but no probe file was reachable; the fixture did not take effect (check GLASS_FRAMEWORK_PATH)'); }
+          else console.log('shell-smoke: viewer — SKIPPED (no framework root on this machine; gate did not run)');
         } else {
           viewerOk = Number(await win.webContents.executeJavaScript(
             `(async () => { await openViewer('${probe.replace(/\\/g, '/')}');

--- a/src/test/desktopEntry.test.ts
+++ b/src/test/desktopEntry.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Linux window association: three names must agree, or the app gets a generic icon and no grouping.
+ *
+ * Electron lowercases the app name for `WM_CLASS` at runtime. electron-builder, when `desktopName`
+ * is absent, derives `StartupWMClass` from `productName` — so the shipped entry said
+ * `StartupWMClass=AIOS` while the running window reported `WM_CLASS = "aios"`, measured with
+ * `xprop`. They never matched, and the desktop environment refused to link the two. The first fix
+ * overrode `StartupWMClass` by hand, which corrected the symptom; setting `desktopName` corrects
+ * the cause, because electron-builder derives BOTH the .desktop filename and StartupWMClass from
+ * it, and Electron derives its runtime app_id from it too.
+ *
+ * The failure mode this guards is silent and cosmetic — nothing crashes, the icon is just wrong —
+ * which is exactly the kind of thing that regresses unnoticed. And it is unverifiable from CI: a
+ * headless xvfb run has no desktop environment to do the association, so the invariant has to be
+ * asserted on the CONFIG rather than observed on a running window.
+ */
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const linux = pkg.build?.linux ?? {};
+
+test('desktopName is set — without it StartupWMClass silently derives from productName', () => {
+  /* This is the whole bug in one assertion. `wmClass = desktopName ?? appInfo.productName`, and
+     productName is "AIOS" while the runtime WM_CLASS is "aios". */
+  assert.ok(typeof pkg.desktopName === 'string' && pkg.desktopName.trim().length > 0,
+    'package.json must declare a top-level desktopName (electron-builder reads it from metadata, '
+    + 'NOT from build.linux); without it StartupWMClass becomes productName and never matches');
+  assert.match(pkg.desktopName, /\.desktop$/, 'desktopName should carry the .desktop suffix');
+});
+
+test('desktopName is lowercase — Electron lowercases WM_CLASS, so anything else cannot match', () => {
+  const base = String(pkg.desktopName).replace(/\.desktop$/, '');
+  assert.equal(base, base.toLowerCase(),
+    `desktopName "${base}" is not lowercase; Electron lowercases the app name for WM_CLASS, so a `
+    + 'mixed-case value produces exactly the mismatch this file exists to prevent');
+  assert.doesNotMatch(base, /[/\\\s]/, 'desktopName flows into filesystem paths — no separators or spaces');
+});
+
+test('syncDesktopName is on, or desktopName does not reach the .desktop filename', () => {
+  /* getDesktopFileName() returns executableName unless syncDesktopName is true. With it off,
+     desktopName still fixes StartupWMClass but the FILE stays aios-app.desktop — and some desktop
+     environments associate by the entry's basename, not by StartupWMClass. Half a fix. */
+  assert.equal(linux.syncDesktopName, true,
+    'linux.syncDesktopName must be true so the .desktop filename matches desktopName; some desktop '
+    + 'environments key association on the filename rather than StartupWMClass');
+});
+
+test('the explicit StartupWMClass override agrees with desktopName', () => {
+  /* The override is kept deliberately: it records the value measured with xprop, and it keeps the
+     entry correct even if desktopName is later removed. But an override that DISAGREES with the
+     derived value is worse than none, because deepAssign lets it win silently. */
+  const derived = String(pkg.desktopName).replace(/\.desktop$/, '');
+  const explicit = linux.desktop?.entry?.StartupWMClass;
+  if (explicit === undefined) return;   // deriving it is legitimate; disagreeing is not
+  assert.equal(explicit, derived,
+    `linux.desktop.entry.StartupWMClass ("${explicit}") disagrees with desktopName ("${derived}"). `
+    + 'The override wins via deepAssign, so a mismatch here ships whatever the override says.');
+});


### PR DESCRIPTION
The two follow-ups from shipping Linux.

## 1. The smoke gates can no longer skip silently

Two gates read the operator's framework — one discovers agents/commands/skills, one opens a file and counts rendered panes. A bare runner has neither, so they failed on **absent fixtures** rather than on the build. That is why smoke was kept out of the release lane, and it is what made this job red on its first-ever real CI run.

Reporting `SKIPPED` was honest, but it left a worse hole: **a gate that CAN skip will eventually skip silently**, and nobody notices the day it stops running for a real reason.

Closed from both sides:

- `scripts/make-vault-fixture.mjs` builds a synthetic framework root — **2 discoverable agents plus 3 that must be filtered out** (an `_index.md`, an `_`-prefixed file, and one with the wrong tag), 1 command, 1 skill, and a README with block content to render.
- `AIOS_SMOKE_STRICT=1` turns *"did not run"* into a **failure**. CI sets both.

The fixture grants **no workspace folder** on purpose: the viewer gate must reach its probe through the framework root alone. Granting one would mask exactly the bug that made that gate pass on a single machine and fail everywhere else.

Proven in both directions:

```
# with the fixture + strict
state  — operator=Fixture, agents=2, commands=1, skills=1     ← 3 decoys correctly filtered
viewer — panes rendered=2 (README.md)
… OK ✓

# no framework root + strict
state  — FAILED: strict mode, but there is no framework root to discover —
         the fixture did not take effect (check GLASS_FRAMEWORK_PATH)
VIEWER FAILED — strict mode, but no probe file was reachable …
… FAIL
```

## 2. `desktopName` — fixing the cause, not the symptom

The shipped `.desktop` **did** carry `StartupWMClass=aios`, extracted from the published `.deb` to confirm it, so #4's fix worked. But the reason it was needed is worse than it looked:

```js
const wmClass = !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/,"") : appInfo.productName;
```

`productName` is `AIOS`; Electron lowercases `WM_CLASS` to `aios`. So electron-builder's **default is broken**, and only an explicit override was holding the entry correct. Setting a top-level `desktopName` (electron-builder reads it from package.json *metadata*, not `build.linux`) makes the `.desktop` filename, `StartupWMClass`, and Electron's runtime app_id all derive from one value. `syncDesktopName` was already `true` but inert without it — which is why the warning kept firing.

Entry filename changes `aios-app.desktop` → `aios.desktop`. Safe right now: the first Linux release published today, so there is nothing installed to leave a stale entry behind.

This one is **unverifiable from CI** — xvfb has no desktop environment to perform the association — so the invariant is asserted on the config instead: `desktopName` present, lowercase, path-safe, `syncDesktopName` on, and any explicit `StartupWMClass` must **agree** with it, because `deepAssign` lets a mismatched override win silently.

## Gates

334 tests (was 330), `check:tokens` clean, and smoke green locally both against a real vault and against the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)