### PR TITLE
fix(theme): restore light-theme muted text to the dark theme's contrast

### DIFF
--- a/renderer/theme.css
+++ b/renderer/theme.css
@@ -488,7 +488,17 @@ body.light {
   --line: rgba(0,0,0,.08);
   --line-strong: rgba(0,0,0,.16);
   --ink: #1c1c20;
-  --subtle: #71717a;
+  /* Muted text, and it is NOT a free choice: 71 rules paint small text (8.5-11.5px)
+     with this token, so whatever it is, it is the readability floor of the whole app.
+     #71717a measured 3.97-4.83:1 against the light surfaces -- under the 4.5:1 AA
+     minimum on every zone except pure white, and that minimum assumes body text, not
+     9.5px letterspaced strip labels like .zlabel (EDITOR / RUN), which measured 3.97:1
+     and were reported as unreadable. The dark theme's own --subtle (#93939c) sits at
+     5.69-6.57:1, so light had ~30% less contrast for the same role -- the palette was
+     tuned in dark and the light value was never re-derived. This value restores parity
+     rather than inventing a target: 5.62-6.83:1, the dark theme's band. Still far
+     quieter than --ink (14.0:1), so the hierarchy the token exists for is unchanged. */
+  --subtle: #5a5a62;
   --edge: inset 0 1px 0 rgba(255,255,255,.7);
   --depth: 0 10px 26px -18px rgba(0,0,0,.25);
 }


### PR DESCRIPTION
## What was reported

An operator running the light theme said the zone strip labels — **EDITOR** and **RUN**, the small caps at the left of each tab strip — were barely readable against the pale background.

They're right, and the problem is wider than those two labels.

## What I measured

`.zlabel` is 9.5px, weight 700, `letter-spacing: .16em`, painted with `var(--subtle)`.

| Label | surface | light | dark |
|---|---|---:|---:|
| EDITOR | `--zone-edit` | **3.97:1** | 6.08:1 |
| RUN | `--zone-term` | **4.27:1** | 6.57:1 |

WCAG AA asks **4.5:1** for normal text, relaxing to 3.0:1 only for large text (≥18.66px bold). Nothing here is large text, so 4.5:1 is the bar — and at 9.5px with letterspacing, 4.5:1 is a floor rather than a target.

Then I swept the whole stylesheet for small text using the same token:

```
71 rules paint text under 12px with var(--subtle).
All 71 are under AA in light theme.
All 71 are comfortable in dark (5.69–6.57:1).
```

So this isn't two labels. `--subtle` is the readability floor of the interface, and in light theme it sits ~30% below where the same token sits in dark:

| | value | range across light/dark surfaces |
|---|---|---|
| dark `--subtle` | `#93939c` | 5.69 – 6.57:1 |
| light `--subtle` | `#71717a` | **3.97 – 4.83:1** |

That gap reads to me as the palette having been tuned in dark, with the light value never re-derived against its own surfaces — not as a light-theme decision that aged badly.

## The change

One value in the `body.light` block: `#71717a` → `#5a5a62`.

`#5a5a62` measures **5.62 – 6.83:1** across `--bg`, `--zone-edit`, `--zone-term`, `--surface` and `--surface-2` — the dark theme's own band.

**Matching dark rather than merely clearing AA is the deliberate part.** Picking the lightest value that scrapes 4.5:1 would introduce a second standard and leave light permanently the weaker theme. Matching restores parity against intent that is already in the file.

The reported labels go **3.97 → 5.62** and **4.27 → 6.04**.

The hierarchy the token exists to express is unchanged: `--ink` is 14.0:1 on the same surfaces, so muted text stays plainly quieter than primary text — it stops being *unreadable* without becoming *loud*.

No rule, selector, font-size or opacity was touched. Dark theme is untouched.

## What I did not change, and why it may be worth a follow-up

Some of those 71 rules stack an `opacity` multiplier on top of the token (`.55`, `.6`, `.7`). Those land under 3:1 in **both** themes even after this change — `.xsectsub` at `.55`, `#pCal td.wknum` at `.5`, `.psubempty` at `.55`. That is a separate concern with a different fix (an explicit dimmer token rather than compositing muted text against its own background), and bundling it here would have made a one-value change into a judgement call about a dozen rules. Happy to open that separately if you want it.

## Testing

```
npm test              602 pass · 0 fail · 5 skipped
npm run check:tokens  ✓ no hardcoded hex outside theme.css · ✓ all pty submits chokepointed
npm run smoke         ✓ window · pty · state · workbench · panel · theme · setup · chrome · shortcuts
```

Smoke's theme assertion (`themeRepaints=true`, light→dark repaint) passes.

`npm run dist` not run. It verifies the packaged artifact, and a token value inside an existing declaration cannot reach packaging — I'd rather say that than imply a gate I didn't run.

Contrast figures are WCAG 2.1 relative luminance, computed against the surface tokens as declared in `theme.css`. The measurement script carried a known-answer control (white/black must be 21.00:1) — which is how I caught a bug in my own helper before it produced a table of plausible wrong numbers.
